### PR TITLE
Add build script for exe packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Stardew Valley Save Editor
+
+This repository contains a simple Stardew Valley save editor written in Python with PyQt5.
+
+## Requirements
+
+- Python 3.8 or higher
+- PyQt5 (install via `pip install -r requirements.txt`)
+- PyInstaller (for packaging to an executable)
+
+## Usage
+
+To run the editor directly:
+
+```bash
+pip install -r requirements.txt
+python 星露谷存档修改器_完整版.py
+```
+
+## Building an executable
+
+If you wish to package the application into a standalone executable, install `PyInstaller` and run the provided script:
+
+```bash
+pip install pyinstaller
+./build_exe.sh
+```
+
+If `pyinstaller` is not available (for example due to network restrictions), the
+build script will fail. Ensure PyInstaller is installed before running the
+script.
+
+The resulting executable will be placed in the `dist/` directory.
+

--- a/build_exe.sh
+++ b/build_exe.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Build the Stardew Valley save editor into an executable using PyInstaller
+
+SCRIPT="星露谷存档修改器_完整版.py"
+pyinstaller --clean --onefile --windowed "$SCRIPT"


### PR DESCRIPTION
## Summary
- add a simple `build_exe.sh` script that invokes PyInstaller
- document how to use the editor and build an executable in `README.md`

## Testing
- `python -m py_compile 星露谷存档修改器_完整版.py`
- `./build_exe.sh` *(fails: pyinstaller not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851439256ac8322833de571590d6523